### PR TITLE
Fix: ajustar notification_url para /api/payments/webhook

### DIFF
--- a/src/routes/payments.py
+++ b/src/routes/payments.py
@@ -232,7 +232,7 @@ def processar_pagamento():
                 "failure": f"{os.getenv('FRONTEND_URL')}/retorno?status=failure",
                 "pending": f"{os.getenv('FRONTEND_URL')}/retorno?status=pending"
             },
-            "notification_url": f"{os.getenv('BACKEND_URL')}/api/pagamentos/webhook",
+            "notification_url": f"{os.getenv('BACKEND_URL')}/api/payments/webhook",
             "external_reference": f"{user_id}_{plano}_{datetime.now().timestamp()}"
         }
         


### PR DESCRIPTION
Esta correção altera o notification_url do Mercado Pago de `/api/pagamentos/webhook` para `/api/payments/webhook` para alinhar com o padrão de nomenclatura das rotas em inglês.

**Alterações:**
- Corrigido notification_url em `src/routes/payments.py` linha 235
- Mudança de `/api/pagamentos/webhook` para `/api/payments/webhook`

**Impacto:**
- Alinha a nomenclatura das URLs com o padrão do projeto
- Mantém compatibilidade com o frontend
- Não afeta outras funcionalidades